### PR TITLE
Update exten.etex

### DIFF
--- a/manual/refman/exten.etex
+++ b/manual/refman/exten.etex
@@ -1604,7 +1604,7 @@ Some attributes are understood by the type-checker:
 
 \begin{verbatim}
 module X = struct
-  [@@warning "+9"]  (* locally enable warning 9 in this structure *)
+  [@@@warning "+9"]  (* locally enable warning 9 in this structure *)
   ...
 end
 


### PR DESCRIPTION
Attribute in  the example should be a floating attribute (or should be moved after the struct's end, and changed to "ocaml.warning" according to http://caml.inria.fr/mantis/view.php?id=6714)
