### PR TITLE
A generated file, copied from the parent during build, was not cleaned.

### DIFF
--- a/manual/cmds/Makefile
+++ b/manual/cmds/Makefile
@@ -8,10 +8,9 @@ FORMAT=../../tools/format-intf
 
 all: $(FILES)
 
-clean:
+clean::
 	rm -f $(FILES)
 	rm -f *~ #*#
-	rm -f warnings-help.etex
 
 .SUFFIXES:
 .SUFFIXES: .tex .etex
@@ -36,3 +35,6 @@ debugger.tex: debugger.etex $(TRANSF)
 
 warnings-help.etex: ../warnings-help.etex
 	cp ../warnings-help.etex .
+
+clean::
+	rm -f warnings-help.etex

--- a/manual/cmds/Makefile
+++ b/manual/cmds/Makefile
@@ -11,6 +11,7 @@ all: $(FILES)
 clean:
 	rm -f $(FILES)
 	rm -f *~ #*#
+	rm -f warnings-help.etex
 
 .SUFFIXES:
 .SUFFIXES: .tex .etex


### PR DESCRIPTION
The file warnings-help.etex is generated by an earlier part of the build, then copied by manual/cmds/Makefile into its directory. It is not cleaned.

I have added an explicit command to clean in. Now, on trunk...

```
make tools; make; make clean
```

...yields a truly clean directory structure.
