### PR TITLE
PR#6912: document new 4.02.2 features

### DIFF
--- a/manual/refman/expr.etex
+++ b/manual/refman/expr.etex
@@ -114,7 +114,7 @@ precedence come first. For infix and prefix symbols, we write
 \begin{tableau}{|l|l|}{Construction or operator}{Associativity}
 \entree{prefix-symbol}{--}
 \entree{".   .(   .[   .{" (see section~\ref{s:bigarray-access})}{--}
-\entree{"#"}{--}
+\entree{"#"\ldots}{--}
 \entree{function application, constructor application, tag
         application, "assert" (see~\ref{s:assert}),
         "lazy" (see~\ref{s:lazy})}{left}

--- a/manual/refman/exten.etex
+++ b/manual/refman/exten.etex
@@ -1849,6 +1849,16 @@ types).
 As a side-effect of this generativity, one is allowed to unpack
 first-class modules in the body of generative functors.
 
+\section{Extension operators} \label{s:ext-ops}
+(Introduced in Ocaml 4.02.2 )
+\begin{syntax}
+infix-symbol:
+          ...
+        | "#" {operator-chars} "#"  {operator-char '|' "#"}
+;
+\end{syntax}
+Operator names starting with a "#" character and containing more than one "#" character in their name are accepted during parsing and rejected during type-checking. These operators can therefore not be used directly in vanilla Ocaml. However, "-ppx" rewriters and other external tools can use this parser leniency to extend the language with new extension specific "#"-operators.
+
 \section{Customizable index operators} \label{s:index-operators}
 
 ( Introduced in OCaml 4.03 )

--- a/manual/refman/lex.etex
+++ b/manual/refman/lex.etex
@@ -218,7 +218,7 @@ otherwise:
       new         object      of          open        or          private
       rec         sig         struct      then        to          true
       try         type        val         virtual     when        while
-      with
+      with        nonrec
 \end{verbatim}
 %
 \goodbreak%

--- a/manual/refman/lex.etex
+++ b/manual/refman/lex.etex
@@ -184,6 +184,7 @@ there are really 3 tokens, with optional blanks between them.
 infix-symbol:
         ('=' || '<' || '>' || '@' || '^' || '|' || '&' ||
          '+' || '-' || '*' || '/' || '$' || '%') { operator-char }
+      | "#" {{ operator-char }}
 ;
 prefix-symbol:
         '!' { operator-char }


### PR DESCRIPTION
This pull request amends the grammar rules in the chapter 6 to add the new "#..." operators.
In the same chapter, the keyword list now mentions the new `nonrec` keyword. A new section in the chapter 7 describes the operators only usable with ppx (or other external tools) support. 
