### PR TITLE
Very minor update of ";;" description in section 6.11.2

### DIFF
--- a/manual/refman/modules.etex
+++ b/manual/refman/modules.etex
@@ -28,7 +28,7 @@ module-expr:
         | '(' module-expr ':' module-type ')'
 ;
 module-items:
-        [';;'] ( definition || expr ) { [';;'] definition || ';;' expr } [';;']
+        {';;'} ( definition || expr ) { {';;'} ( definition || ';;' expr) } {';;'}
 ;
 %\end{syntax} \begin{syntax}
 definition:
@@ -77,12 +77,11 @@ definition may refer to names bound by earlier definitions in the same
 structure.
 
 For compatibility with toplevel phrases (chapter~\ref{c:camllight}),
-an optional @";;"@ is allowed after each
-definition in a structure. The @";;"@ has no semantic meaning. Also for
-compatibility, @expr@ is allowed as a component of a structure,
-meaning @'let' '_' '=' expr@, i.e. evaluate @expr@ for its side-effects.
-In this case, the @";;"@ of the previous component (if any) is not
-optional.
+optional @";;"@ are allowed after and before each definition in a structure. These
+@";;"@ have no semantic meanings. Similarly, an @expr@ preceded by ";;" is allowed as
+a component of a structure. It is equivalent to @'let' '_' '=' expr@, i.e. @expr@ is
+evaluated for its side-effects but is not bound to any identifier. If @expr@ is
+the first component of a structure, the preceding ";;" can be omitted.
 
 \subsubsection*{Value definitions}
 


### PR DESCRIPTION
I recently (re?)read this section of the manual due to some comments on the freenode
irc channel. Since the section was out-of-sync with the current grammar and somehow
confusing, I took some time to reword it a little bit and update the grammar description.

Feel free to ignore the patch. It is a very minor point and not that consensual. But it is 
probably a good idea to at least keep the pull request as marker for potential future 
improvements.
### Details of the pull request
- The description of `;;` is sligthly reworded. In particular, the new text groups together `;;` 
  and `expr`. With this modification, `;;` is no longer first introduced has a compatibility 
  placeholder with no semantic meaning ; which is then explained to be not optional in some
  situations.
- The grammar update reflects the current grammar which allow repetitions of `;;`. If I am
  not mistaken, the new text should be a faithful description of the grammar rather than just
  an approximation.
