### PR TITLE
ocamllex: refill continuation only takes lexbuf as argument

### DIFF
--- a/manual/cmds/lexyacc.etex
+++ b/manual/cmds/lexyacc.etex
@@ -350,8 +350,8 @@ module Make (M : sig
              end)
 = struct
 
-let refill_handler k lexbuf arg =
-    M.bind (M.on_refill lexbuf) (fun () -> k lexbuf arg)
+let refill_handler k lexbuf =
+    M.bind (M.on_refill lexbuf) (fun () -> k lexbuf)
 
 }
 


### PR DESCRIPTION
Other arguments to lexer rules are captured in the continuation to keep its type simple and uniform.
